### PR TITLE
Add sanity check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,20 @@
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  quality-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          # Use lts/* when 24 is no longer supported
+          node-version: '24'
+      - name: Run quality checks
+        run: node ./contrib/qa.ts ./tangutcjkk.dict.yaml

--- a/contrib/qa.ts
+++ b/contrib/qa.ts
@@ -1,0 +1,95 @@
+import fs from "node:fs";
+import path from "node:path";
+
+function main() {
+  const dictPath = process.argv[2];
+  if (process.argv.length !== 3) {
+    console.error("Usage: node ./contrib/qa.ts ./tangutcjkk.dict.yaml");
+    process.exitCode = 1;
+    return;
+  }
+  const content = fs.readFileSync(path.resolve(dictPath), "utf-8");
+  const dict = readCangjieDict(content);
+  code_should_be_lowercase_alphabetic(dict);
+  short_should_be_subsequence_of_full(dict);
+}
+
+type CangjieCode = { short: string, full: string };
+/**
+ * Reads a Cangjie dictionary file and returns a map of characters to their Cangjie codes.
+ * @param dictContent Content of a Cangjie dictionary file.
+ * @returns A map of characters to their Cangjie codes.
+ */
+function readCangjieDict(dictContent: string): Map<string, CangjieCode> {
+  const dict = new Map<string, CangjieCode>();
+  const lines = dictContent.split("\r\n");
+  for (const line of lines) {
+    const parts = line.split("\t");
+    if (parts.length === 2) {
+        const [char, code] = parts;
+        if (code.startsWith("p")) {
+            // Skip component codes
+            continue;
+        }
+        if (dict.has(char)) {
+            const entry = dict.get(char)!;
+            entry.full = code;
+        } else {
+            dict.set(char, { short: code, full: code });
+        }
+    }
+  }
+  return dict;
+}
+
+/**
+ * Checks if a string is a subsequence of another string.
+ * @param sub The substring to check.
+ * @param str The string to check against.
+ * @returns True if `sub` is a subsequence of `str`, false otherwise.
+ * @example
+ * is_subsequence("abc", "aXbYcZ") // true
+ * is_subsequence("abc", "acb") // false
+ */
+function is_subsequence(sub: string, str: string): boolean {
+  let subIndex = 0;
+  for (let i = 0; i < str.length && subIndex < sub.length; i++) {
+    if (str[i] === sub[subIndex]) {
+      subIndex++;
+    }
+  }
+  return subIndex === sub.length;
+}
+
+/**
+ * Checks if all Cangjie codes in the dictionary are lowercase alphabetic.
+ * @param dict A map of characters to their Cangjie codes.
+ */
+function code_should_be_lowercase_alphabetic(dict: Map<string, CangjieCode>) {
+  const codeRegex = /^[a-z]+$/;
+  for (const [char, code] of dict) {
+    if (!codeRegex.test(code.short)) {
+      console.error(`Short code "${code.short}" for character U+${char.codePointAt(0)!.toString(16).toUpperCase()} "${char}" is not lowercase alphabetic`);
+      process.exitCode = 1;
+    }
+    if (!codeRegex.test(code.full)) {
+      console.error(`Full code "${code.full}" for character U+${char.codePointAt(0)!.toString(16).toUpperCase()} "${char}" is not lowercase alphabetic`);
+      process.exitCode = 1;
+    }
+  }
+}
+
+/**
+ * Checks if all short Cangjie codes in the dictionary are subsequences of their full codes.
+ * @param dict A map of characters to their Cangjie codes.
+ */
+function short_should_be_subsequence_of_full(dict: Map<string, CangjieCode>) {
+  for (const [char, code] of dict) {
+    if (!is_subsequence(code.short, code.full)) {
+      console.error(`Short code "${code.short}" is not a subsequence of full code "${code.full}" for character U+${char.codePointAt(0)!.toString(16).toUpperCase()} "${char}"`);
+      process.exitCode = 1;
+    }
+  }
+}
+
+main();

--- a/tangutcjkk.dict.yaml
+++ b/tangutcjkk.dict.yaml
@@ -8646,7 +8646,7 @@ sort: original
 𘍓	cqmbq
 𘍓	cbqmbq
 𘍔	cqsx
-𘍔	cbgsx
+𘍔	cbqsx
 𘍕	cqhqb
 𘍕	cbqhqb
 𘍖	cqdjq
@@ -8656,7 +8656,7 @@ sort: original
 𘍘	cqwna
 𘍘	cbqwnta
 𘍙	cqttu
-𘍙	cbgttbtu
+𘍙	cbqttbtu
 𘍚	cqmjl
 𘍚	cbqmtjal
 𘍛	cqfdw


### PR DESCRIPTION
In this PR we setup basic CI and add a quality check script. The quality check scripts currently enforces that

- All cangjie codes are lowercase alphabetic
- The short cangjie code is a subsequence of the full cangjie code

Currently the CI should fail because there are quite a few errors in the dictionary. I will fix them in this PR.